### PR TITLE
Fix link for DataKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Some notable components include:
 
  * [HyperKit](https://github.com/docker/hyperkit/), a toolkit for
    embedding hypervisor capabilities in your application
- * [DataKit](https://github.com/docker/hyperkit/), a tool to orchestrate
+ * [DataKit](https://github.com/docker/datakit), a tool to orchestrate
    applications using a 9P dataflow
  * [VPNKit](https://github.com/docker/vpnkit), a set of tools and
    services for helping HyperKit VMs interoperate with host VPN


### PR DESCRIPTION
The link to DataKit component of Docker for Mac was incorrect in README.md, this change fixes that.