### PR TITLE
Improve the wording of the vmnetd-comm-failure description

### DIFF
--- a/.nurse/problems/vmnetd-comm-failure.json
+++ b/.nurse/problems/vmnetd-comm-failure.json
@@ -1,6 +1,13 @@
 {
   "in_file": "docker-system.log",
   "matches": ["Communication with networking components failed"],
-  "description": "The UI failed to communicate with the networking helper process. Deleting `/Library/PrivilegedHelperTools/com.docker.vmnetd` and restarting the application should help you. Please re-open that issue if your problem persist.",
+  "description": "The UI failed to communicate with the networking helper process.
+
+Try the following steps:
+- stop Docker for Mac
+- delete the file `/Library/PrivilegedHelperTools/com.docker.vmnetd`
+- start Docker for Mac
+
+Hopefully this will (re-)install the networking helper process properly. Please re-open this issue if your problem persists.",
   "link_to_issues": [ [ "docker/for-mac", 61 ] ]
 }


### PR DESCRIPTION
Rewrite the description to

- use a simpler imperative style (stop .. delete ... start ...)
- be more cut 'n pastable into issue comments

Signed-off-by: David Scott <dave.scott@docker.com>