### PR TITLE
Add repo config detecting lifecycle events

### DIFF
--- a/.nurse/config.json
+++ b/.nurse/config.json
@@ -1,0 +1,6 @@
+{
+    "lifecycle": {
+        "files": ["docker-system.log", "docker-system-os.log"],
+        "matches" : ["Application version", "UpdateMigrator: migrator:", "Analytics: " ]
+    }
+}


### PR DESCRIPTION
Currently ocaml-re (used by the analysis tool) does not support negative
lookahead so we cannot use "Analystics: (?!Sent heartbeat event)" to avoid the
more spammy heart beat message.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>