### PR TITLE
Markdown fixup and moved repo info

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,5 +1,9 @@
+# FAQ
+
 ## Debugging
+
 ### What can I do to help?
+
 1. First, please refrain from immediately resetting/uninstalling Docker for Mac:
    it will destroy the logs we need to understand the problem.
 2. Make sure you are using the latest version of your channel (Stable or Edge).
@@ -9,29 +13,34 @@
    most recent Edge release addresses your concerns.  Because we continuously
    improve the Diagnostics, it does help us if you can provide Diagnostics with
    the most recent release of Docker for Mac.
-5. Check whether there are [open
-   issues](https://github.com/docker/for-mac/issues) similar to problem
-6. Create a new issue, with a meaningful title, and the Diagnostic ID you
-   obtained above, and all the relevant details.
+5. Check whether there are [open issues](https://github.com/docker/for-mac/issues) similar to your problem
+6. Create a new issue, with a meaningful title, the Diagnostic ID you obtained above,
+   and all the relevant details.
 
 ## Versions of Docker for Mac
+
 ### Downgrading
+
 There is no GUI interface to install a previous version of Docker for Mac,
 however you can still download previous versions from here:
 
-https://docs.docker.com/docker-for-mac/release-notes/
+<https://docs.docker.com/docker-for-mac/release-notes/>
 
 Note the "Download" link for each release.
 
 ## Kubernetes
+
 ### How can I get logs
+
 ```sh
-$ docker run --rm -it --privileged --pid=host justincormack/nsenter1 /bin/sh -c "cat /var/log/kubelet.err.log"
+docker run --rm -it --privileged --pid=host justincormack/nsenter1 /bin/sh -c "cat /var/log/kubelet.err.log"
 ```
 
 ### getsockopt: connection refused
+
 > When reading `kubelet.err.log` I have tons of:
-```
+
+```log
 E0131 10:04:34.458760    1193 kubelet_node_status.go:107] Unable to register node "docker-for-desktop" with API server: Post https://192.168.65.3:6443/api/v1/nodes: dial tcp 192.168.65.3:6443: getsockopt: connection refused
 E0131 10:04:35.403894    1193 reflector.go:205] k8s.io/kubernetes/pkg/kubelet/config/apiserver.go:47: Failed to list *v1.Pod: Get https://192.168.65.3:6443/api/v1/pods?fieldSelector=spec.nodeName%3Ddocker-for-desktop&resourceVersion=0: dial tcp 192.168.65.3:6443: getsockopt: connection refused
 E0131 10:04:35.403894    1193 reflector.go:205] k8s.io/kubernetes/pkg/kubelet/kubelet.go:422: Failed to list *v1.Node: Get https://192.168.65.3:6443/api/v1/nodes?fieldSelector=metadata.name%3Ddocker-for-desktop&resourceVersion=0: dial tcp 192.168.65.3:6443: getsockopt: connection refused
@@ -42,4 +51,4 @@ E0131 10:04:36.405721    1193 reflector.go:205] k8s.io/kubernetes/pkg/kubelet/ku
 ```
 
 This is not a problem: this is `kubelet` trying to connect to API server when
-the latter is reading ready yet.
+the latter is not reading ready yet.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-## Docker Desktop for Mac
+# Docker Desktop for Mac
 
-### Getting Docker Desktop for Mac
+## Getting Docker Desktop for Mac
 
 Docker Desktop for Mac is free to [download](https://store.docker.com/editions/community/docker-ce-desktop-mac).
 
-### Documentation
+## Documentation
 
 If you don't understand something about Docker Desktop for Mac, the [extensive
 documentation](https://docs.docker.com/docker-for-mac/) is a great place
 to look for answers.
 
-### Support
+## Support
 
 Support for Docker Desktop is available to Docker customers on a Pro or Team plan
 by completing the [Desktop support form](https://hub.docker.com/support/desktop/).
@@ -21,7 +21,7 @@ on a best-effort basis. Support requests in this repository (i.e., trouble insta
 or using the software) will be ignored, but community support is available from the
 [Docker community Slack](https://www.docker.com/docker-community).
 
-### This Repository
+## This Repository
 
 This repository contains an issue tracker for Docker Desktop for Mac -- an
 integrated Docker experience on OS X or macOS. If you find a problem
@@ -30,7 +30,7 @@ issues](https://github.com/docker/for-mac/issues) or search from the bar
 at the top (`s` to focus) and then, if you don't find your issue, [open
 a new issue](https://github.com/docker/for-mac/issues/new).
 
-### Component Projects
+## Component Projects
 
 Docker Desktop for Mac uses many open source components. A full list of
 components and licenses is available inside of Docker Desktop from `About Docker Desktop
@@ -38,10 +38,10 @@ components and licenses is available inside of Docker Desktop from `About Docker
 
 Some notable components include:
 
- * [HyperKit](https://github.com/docker/hyperkit/), a toolkit for
+* [HyperKit](https://github.com/docker/hyperkit/), a toolkit for
    embedding hypervisor capabilities in your application
- * [DataKit](https://github.com/docker/datakit/), a tool to orchestrate
+* [DataKit](https://github.com/docker/datakit/), a tool to orchestrate
    applications using a 9P dataflow
- * [VPNKit](https://github.com/docker/vpnkit), a set of tools and
+* [VPNKit](https://github.com/docker/vpnkit), a set of tools and
    services for helping HyperKit VMs interoperate with host VPN
    configurations

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Docker Desktop for Mac
 
+This repository contains an issue tracker for Docker Desktop for Mac -- an
+integrated Docker experience on OS X or macOS. If you find a problem
+with the software, first [browse the existing
+issues](https://github.com/docker/for-mac/issues) or search from the bar
+at the top (`s` to focus) and then, if you don't find your issue, [open
+a new issue](https://github.com/docker/for-mac/issues/new).
+
 ## Getting Docker Desktop for Mac
 
 Docker Desktop for Mac is free to [download](https://store.docker.com/editions/community/docker-ce-desktop-mac).
@@ -20,15 +27,6 @@ Bugs with the Docker Desktop for Mac software can be filed as issues in this
 on a best-effort basis. Support requests in this repository (i.e., trouble installing
 or using the software) will be ignored, but community support is available from the
 [Docker community Slack](https://www.docker.com/docker-community).
-
-## This Repository
-
-This repository contains an issue tracker for Docker Desktop for Mac -- an
-integrated Docker experience on OS X or macOS. If you find a problem
-with the software, first [browse the existing
-issues](https://github.com/docker/for-mac/issues) or search from the bar
-at the top (`s` to focus) and then, if you don't find your issue, [open
-a new issue](https://github.com/docker/for-mac/issues/new).
 
 ## Component Projects
 


### PR DESCRIPTION
This PR has the same markdown linting and minor content changes as the other markdown-fixup PR.
In addition I have moved the "about this repository" content to what is typically the description section under the title.
